### PR TITLE
[feat] 공통 컴포넌트 헤더,푸터 구현  

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@eslint/js": "^9.36.0",
         "@types/axios": "^0.9.36",
+        "@types/node": "^24.6.0",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "@typescript-eslint/eslint-plugin": "^8.44.1",
@@ -1535,6 +1536,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.0.tgz",
+      "integrity": "sha512-F1CBxgqwOMc4GKJ7eY22hWhBVQuMYTtqI8L0FcszYcpYX0fzfDGpez22Xau8Mgm7O9fI+zA/TYIdq3tGWfweBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.13.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.14",
@@ -6759,6 +6770,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
+      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@eslint/js": "^9.36.0",
     "@types/axios": "^0.9.36",
+    "@types/node": "^24.6.0",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@typescript-eslint/eslint-plugin": "^8.44.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,13 @@
+import MainLayout from './layouts/MainLayout';
+
 const App = () => {
   return (
-    <div className="min-h-screen bg-white flex flex-col items-center justify-center">
-      <h1 className="text-5xl text-red-600 font-extrabold">핫 식스 프론트엔드 </h1>
-      <p className="mt-4 text-gray-500">Tailwind 테스트</p>
-    </div>
+    <MainLayout>
+      <div className="p-10 text-center">
+        <h1 className="text-4xl font-bold text-rose-500">핫 식스 프론트엔드</h1>
+        <p className="mt-2 text-gray-500">Tailwind 테스트 중입니다</p>
+      </div>
+    </MainLayout>
   );
 };
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,38 @@
+const Footer = () => {
+  return (
+    <footer className="bg-white border-t text-sm text-gray-600">
+      <div className="max-w-7xl mx-auto px-6 py-10 grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div>
+          <h2 className="text-rose-500 font-bold text-lg mb-2">Pickple</h2>
+          <p>
+            픽플은 프리랜서와 클라이언트를 연결하는 플랫폼입니다. <br />
+            AI 시스템으로 정확한 매칭을 제공합니다.
+          </p>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-2">서비스</h3>
+          <ul className="space-y-1">
+            <li>프리랜서 찾기</li>
+            <li>프로젝트 찾기</li>
+            <li>프리랜서 되기</li>
+            <li>AI 매칭 서비스</li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-2">고객 지원</h3>
+          <ul className="space-y-1">
+            <li>도움말</li>
+            <li>문의 하기</li>
+            <li>신고 하기</li>
+            <li>자주 묻는 질문</li>
+          </ul>
+        </div>
+      </div>
+      <div className="text-center text-xs text-gray-400 py-4 border-t">
+        © 2024 Pickple. All rights reserved.
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -32,7 +32,7 @@ const Footer = () => {
       </div>
 
       <div className="text-center text-xs text-gray-400 py-4 border-t">
-        © 2024 Pickple. All rights reserved.
+        © {new Date().getFullYear()} Pickple. All rights reserved.
       </div>
     </footer>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,33 +1,36 @@
 const Footer = () => {
   return (
     <footer className="bg-white border-t text-sm text-gray-600">
-      <div className="max-w-7xl mx-auto px-6 py-10 grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div>
+      <div className="max-w-7xl mx-auto px-6 py-10 flex flex-col md:flex-row justify-between gap-10">
+        <div className="md:w-1/3">
           <h2 className="text-rose-500 font-bold text-lg mb-2">Pickple</h2>
           <p>
             픽플은 프리랜서와 클라이언트를 연결하는 플랫폼입니다. <br />
             AI 시스템으로 정확한 매칭을 제공합니다.
           </p>
         </div>
-        <div>
-          <h3 className="font-semibold mb-2">서비스</h3>
-          <ul className="space-y-1">
-            <li>프리랜서 찾기</li>
-            <li>프로젝트 찾기</li>
-            <li>프리랜서 되기</li>
-            <li>AI 매칭 서비스</li>
-          </ul>
-        </div>
-        <div>
-          <h3 className="font-semibold mb-2">고객 지원</h3>
-          <ul className="space-y-1">
-            <li>도움말</li>
-            <li>문의 하기</li>
-            <li>신고 하기</li>
-            <li>자주 묻는 질문</li>
-          </ul>
+        <div className="md:w-2/3 flex flex-col sm:flex-row justify-end gap-12 text-right">
+          <div>
+            <h3 className="font-semibold mb-2">서비스</h3>
+            <ul className="space-y-1">
+              <li>프리랜서 찾기</li>
+              <li>프로젝트 찾기</li>
+              <li>프리랜서 되기</li>
+              <li>AI 매칭 서비스</li>
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-semibold mb-2">고객 지원</h3>
+            <ul className="space-y-1">
+              <li>도움말</li>
+              <li>문의 하기</li>
+              <li>신고 하기</li>
+              <li>자주 묻는 질문</li>
+            </ul>
+          </div>
         </div>
       </div>
+
       <div className="text-center text-xs text-gray-400 py-4 border-t">
         © 2024 Pickple. All rights reserved.
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 const Header = () => {
   return (
     <header className="w-full border-b bg-white">
-      <div className="bg-gray-800 text-white text-sm py-1 px-4">로그인 페이지</div>
       <div className="flex justify-between items-center px-6 py-4">
         <Link to="/" className="text-2xl font-bold text-rose-400">
           Pickple

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,24 +3,26 @@ import { Link } from 'react-router-dom';
 const Header = () => {
   return (
     <header className="w-full border-b bg-white">
-      <div className="flex justify-between items-center px-6 py-4">
+      <div className="flex justify-between items-center px-6 py-4 max-w-7xl mx-auto">
         <Link to="/" className="text-2xl font-bold text-rose-400">
           Pickple
         </Link>
-        <nav className="flex space-x-6 text-sm text-gray-700 font-medium">
+        <nav className="flex items-center space-x-8 text-sm text-gray-700 font-medium">
           <Link to="/freelancers" className="hover:text-rose-400">
             프리랜서 찾기
           </Link>
           <Link to="/projects" className="hover:text-rose-400">
             프로젝트 찾기
           </Link>
-          <Link to="/login" className="hover:text-rose-400">
-            로그인
-          </Link>
-          <span className="text-gray-300">|</span>
-          <Link to="/signup" className="hover:text-rose-400">
-            회원가입
-          </Link>
+          <div className="flex items-center space-x-2">
+            <Link to="/login" className="hover:text-rose-400">
+              로그인
+            </Link>
+            <span className="text-gray-300">|</span>
+            <Link to="/signup" className="hover:text-rose-400">
+              회원가입
+            </Link>
+          </div>
         </nav>
       </div>
     </header>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,31 @@
+import { Link } from 'react-router-dom';
+
+const Header = () => {
+  return (
+    <header className="w-full border-b bg-white">
+      <div className="bg-gray-800 text-white text-sm py-1 px-4">로그인 페이지</div>
+      <div className="flex justify-between items-center px-6 py-4">
+        <Link to="/" className="text-2xl font-bold text-rose-400">
+          Pickple
+        </Link>
+        <nav className="flex space-x-6 text-sm text-gray-700 font-medium">
+          <Link to="/freelancers" className="hover:text-rose-400">
+            프리랜서 찾기
+          </Link>
+          <Link to="/projects" className="hover:text-rose-400">
+            프로젝트 찾기
+          </Link>
+          <Link to="/login" className="hover:text-rose-400">
+            로그인
+          </Link>
+          <span className="text-gray-300">|</span>
+          <Link to="/signup" className="hover:text-rose-400">
+            회원가입
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,0 +1,15 @@
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+import type { ReactNode } from 'react';
+
+const MainLayout = ({ children }: { children: ReactNode }) => {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <main className="flex-grow">{children}</main>
+      <Footer />
+    </div>
+  );
+};
+
+export default MainLayout;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,7 +22,12 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+
+    "baseUrl": "./src", // src 폴더를 기준으로 절대 경로 시작
+    "paths": {
+      "@/*": ["*"] // '@/components/...' → 'src/components/...'
+    }
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,14 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+/// <reference types="node" />
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #4 

## 📝 작업 내용

> 모든곳에서 공통적으로 사용하는 헤더,푸터 컴포넌트를 구현 후, 적용하였습니다.

## 🖼️ 스크린샷 (선택)
<img width="1919" height="936" alt="화면 캡처 2025-09-30 095223" src="https://github.com/user-attachments/assets/269dca97-4cfd-4641-b68f-a0894e6101fe" />



## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 전역 레이아웃 도입으로 상단 네비게이션과 하단 푸터가 추가되었습니다.
  - 홈 화면에 정돈된 본문과 업데이트된 타이포그래피(크기/색상/문구)가 반영되었습니다.
  - 라우터가 도입되어 앱이 라우팅 컨텍스트에서 동작합니다.

- Refactor
  - 앱 구조를 공용 레이아웃 중심으로 단순화하고 렌더 흐름을 통일했습니다.

- Chores
  - 개발 환경 개선: Node 타입 선언 추가, 소스 절대 경로 별칭 및 빌드 설정에 alias 추가. 사용자 영향 없음.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->