### PR TITLE
[feat] Proposal 페이지 라우트 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,10 @@
 import MainLayout from './layouts/MainLayout';
+import AppRouter from './router/AppRouter';
 
 const App = () => {
   return (
     <MainLayout>
-      <div className="p-10 text-center">
-        <h1 className="text-4xl font-bold text-rose-500">핫 식스 프론트엔드</h1>
-        <p className="mt-2 text-gray-500">Tailwind 테스트 중입니다</p>
-      </div>
+      <AppRouter />
     </MainLayout>
   );
 };

--- a/src/features/proposal/index.tsx
+++ b/src/features/proposal/index.tsx
@@ -1,0 +1,54 @@
+const ProposalMatchPage = () => {
+  return (
+    <div className="min-h-screen bg-gray-100">
+      {/* 헤더 */}
+      <header className="bg-white shadow p-4 flex justify-center items-center">
+        <nav className="flex gap-6">
+          <a href="#">문서/글쓰기</a>
+          <a href="#">IT/프로그래밍</a>
+          <a href="#">마케팅</a>
+          <a href="#">취미 레슨</a>
+          <a href="#">세무/법무/노무</a>
+          <a href="#">창업/사업</a>
+          <a href="#">번역/통역</a>
+        </nav>
+      </header>
+
+      {/* 본문 */}
+      <main className="max-w-2xl mx-auto py-12 px-4">
+        {/* 프로젝트 설명 카드 */}
+        <div className="bg-gray-200 h-48 flex items-center justify-center rounded-lg">
+          프로젝트에 대한 설명 및 관련 사진
+        </div>
+
+        {/* 카테고리 드롭다운 */}
+        <div className="mt-6">
+          <select className="w-full border rounded p-2">
+            <option>카테고리</option>
+            <option>문서/글쓰기</option>
+            <option>IT/프로그래밍</option>
+            <option>마케팅</option>
+            <option>취미 레슨</option>
+            <option>세무/법무/노무</option>
+            <option>창업/사업</option>
+            <option>번역/통역</option>
+          </select>
+        </div>
+
+        {/* 매칭 확인 영역 */}
+        <div className="mt-10 bg-emerald-400 text-white text-center p-6 rounded-lg text-lg font-medium">
+          아샷추 님의 프로젝트와 매칭하시겠습니까?
+        </div>
+
+        {/* 버튼 */}
+        <div className="flex justify-center mt-6">
+          <button className="bg-[#FF6B6B] hover:bg-pink-600 text-white px-6 py-2 rounded-lg">
+            매칭하기
+          </button>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default ProposalMatchPage;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,10 @@
+const Home = () => {
+  return (
+    <div className="p-10 text-center">
+      <h1 className="text-4xl font-bold text-rose-500">핫 식스 프론트엔드</h1>
+      <p className="mt-2 text-gray-500">Tailwind 테스트 중입니다</p>
+    </div>
+  );
+};
+
+export default Home;

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -1,0 +1,7 @@
+import ProposalPage from '@/features/proposal';
+
+const Proposal = () => {
+  return <ProposalPage />;
+};
+
+export default Proposal;

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -1,0 +1,12 @@
+import { Routes, Route } from 'react-router-dom';
+import { routes } from './routes';
+
+export default function AppRouter() {
+  return (
+    <Routes>
+      {routes.map(({ path, element }) => (
+        <Route key={path} path={path} element={element} />
+      ))}
+    </Routes>
+  );
+}

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,5 +1,5 @@
-import ProposalPage from '../pages/Proposal';
-import Home from '../pages/Home';
+import Home from '../pages/home';
+import ProposalPage from '../pages/proposal';
 
 export const routes = [
   { path: '/', element: <Home /> },

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,4 +1,4 @@
-import Home from '../pages/home';
+import Home from '../pages/Home';
 import ProposalPage from '../pages/proposal';
 
 export const routes = [

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,5 +1,7 @@
-import ProposalPage from '../pages/proposal'; // ✅ 추가
+import ProposalPage from '../pages/Proposal';
+import Home from '../pages/Home';
 
 export const routes = [
-  { path: '/proposal', element: <ProposalPage /> }, // ✅ 추가
+  { path: '/', element: <Home /> },
+  { path: '/proposal', element: <ProposalPage /> },
 ];

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,0 +1,5 @@
+import ProposalPage from '../pages/proposal'; // ✅ 추가
+
+export const routes = [
+  { path: '/proposal', element: <ProposalPage /> }, // ✅ 추가
+];


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #6 

## 📝 작업 내용

> ProposalPage 컴포넌트 추가 (src/features/proposal/index.tsx)
> router/routes.tsx에 '/proposal' 경로 추가
> Proposal 페이지 UI 초안 구현

> 기존의 Home 페이지 부분도 임시로 라우트에 넣었습니다.

## 🖼️ 스크린샷 (선택)

<img width="2173" height="1319" alt="image" src="https://github.com/user-attachments/assets/c28253a5-a86d-4101-abda-39f6b15e9169" />

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 앱에 전역 라우터 도입으로 홈("/")과 제안 매칭("/proposal")으로 이동 가능
  - 제안 매칭 페이지 추가: 프로젝트 설명 카드, 카테고리 선택, 매칭 안내 섹션 및 중앙 액션 버튼 제공
  - 홈 페이지 추가: 간단한 헤더와 안내 문구 표시
- 리팩터링
  - 기존 정적 헤더를 제거하고 전역 라우터로 화면 전환을 관리하도록 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->