### PR TITLE
[feat] 리뷰 작성 페이지에 리뷰 등록 API 연동 

### DIFF
--- a/src/features/review/ReviewWritePage.tsx
+++ b/src/features/review/ReviewWritePage.tsx
@@ -1,9 +1,34 @@
 import { useState } from 'react';
 import StarRating from '@/components/StarRating';
+import { postReview } from '@/features/review/apis/api';
 
 const ReviewWritePage = () => {
   const [rating, setRating] = useState(0);
   const [content, setContent] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!rating || !content) {
+      alert('평점과 후기를 모두 입력해주세요.');
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      const response = await postReview({
+        projectId: 1, // 실제 프로젝트 ID로 변경
+        rating,
+        comment: content,
+        images: [], // S3 업로드 후 URL 배열 넣기
+      });
+      alert(response.data || '리뷰 등록 완료');
+    } catch (error) {
+      console.error(error);
+      alert('리뷰 등록 중 오류가 발생했습니다.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
     <div className="bg-white min-h-screen px-6 py-10 max-w-2xl mx-auto">
@@ -50,8 +75,12 @@ const ReviewWritePage = () => {
         </div>
 
         <div className="text-right">
-          <button className="bg-teal-500 text-white px-6 py-2 rounded-md font-semibold hover:bg-teal-600">
-            등록
+          <button
+            className="bg-teal-500 text-white px-6 py-2 rounded-md font-semibold hover:bg-teal-600 disabled:opacity-50"
+            disabled={isSubmitting}
+            onClick={handleSubmit}
+          >
+            {isSubmitting ? '등록 중...' : '등록'}
           </button>
         </div>
       </div>

--- a/src/features/review/apis/api.ts
+++ b/src/features/review/apis/api.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import type { ReviewRequestDto, CommonResponse } from '../types/types';
+
+const api = axios.create({
+  baseURL: 'http://localhost:8080/api/v1',
+  headers: {
+    'Content-Type': 'application/json',
+    // 나중에 로그인 연동 시:
+    // Authorization: `Bearer ${token}`,
+  },
+});
+
+// 리뷰 등록 API
+export const postReview = async (dto: ReviewRequestDto) => {
+  const response = await api.post<CommonResponse<string>>('/reviews', dto);
+  return response.data;
+};

--- a/src/features/review/types/types.ts
+++ b/src/features/review/types/types.ts
@@ -1,0 +1,12 @@
+export interface ReviewRequestDto {
+  projectId: number;
+  rating: number;
+  comment: string;
+  images?: string[];
+}
+
+export interface CommonResponse<T> {
+  errorCode: number;
+  message: string;
+  data: T;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #19 

## 📝 작업 내용

> 백엔드에서 작업한 리뷰 등록 API를 프론트와 연동하여 직접 리뷰가 작성되는지 확인했습니다.
> 현재 로그인 및 회원가입 API가 프론트에서 연동이 안돼서 스웨거에서 발급된 토큰을 가져와서 연동 테스트 하였습니다.

## 🖼️ 스크린샷 (선택)
### 리뷰 작성 연동 관련 성공
<img width="720" height="401" alt="프론트리뷰등록성공" src="https://github.com/user-attachments/assets/377a31ec-6bc1-46a4-bd86-c1774b748aaf" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 리뷰 제출 기능 추가: 프로젝트에 평점, 코멘트, 이미지와 함께 리뷰를 등록할 수 있습니다.
  * 입력 검증 강화: 필수 항목 누락 시 알림으로 안내합니다.
  * 제출 상태 표시: 제출 중 버튼 비활성화 및 “등록 중...” 로딩 라벨을 표시합니다.
  * 결과 피드백: 서버 응답에 따라 성공/오류 메시지를 사용자에게 명확히 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->