### PR TITLE
[fix] 프론트에서 설정한 경로 수정하여 백엔드와 로그인,회원가입,로그아웃 연동 

### DIFF
--- a/src/features/auth/auth.ts
+++ b/src/features/auth/auth.ts
@@ -18,10 +18,10 @@ export const login = async (credentials: {
   email: string;
   password: string;
 }): Promise<UserLoginResponseDto> => {
-  const res = await axiosInstance.post('/auth/login/basic', credentials);
+  const res = await axiosInstance.post('/users/login', credentials);
   return res.data as UserLoginResponseDto;
 };
 
 export const logout = async (): Promise<void> => {
-  await axiosInstance.delete('/auth/logout');
+  await axiosInstance.delete('/users/logout');
 };

--- a/src/features/review/apis/api.ts
+++ b/src/features/review/apis/api.ts
@@ -1,17 +1,7 @@
-import axios from 'axios';
 import type { ReviewRequestDto, CommonResponse } from '../types/types';
+import axiosInstance from '@/services/axios';
 
-const api = axios.create({
-  baseURL: 'http://localhost:8080/api/v1',
-  headers: {
-    'Content-Type': 'application/json',
-    // 나중에 로그인 연동 시:
-    // Authorization: `Bearer ${token}`,
-  },
-});
-
-// 리뷰 등록 API
 export const postReview = async (dto: ReviewRequestDto) => {
-  const response = await api.post<CommonResponse<string>>('/reviews', dto);
+  const response = await axiosInstance.post<CommonResponse<string>>('/reviews', dto);
   return response.data;
 };

--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -6,7 +6,7 @@ import axios from 'axios';
  */
 
 export const axiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL ?? '/api', // API의 기본 URL (환경 변수에서 가져오거나 기본값 사용)
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? '/api/v1', // API의 기본 URL (환경 변수에서 가져오거나 기본값 사용)
   withCredentials: true, // 쿠키 등 인증 정보 포함
   headers: {
     'Content-Type': 'application/json', // 기본 요청 헤더


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #21 

## 📝 작업 내용

> 현재 로그인,회원가입 등 백엔드 컨트롤러에서 만든 경로와 불일치하여 401 에러가 나왔는데 경로 수정으로 문제 해결  
> 리뷰 작성쪽 api 연동도 전역 axiosInstance로 사용하여 로그인 한 사용자와의 연동 

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 인증 API 경로를 /auth/*에서 /users/*로 정리하여 일관성 향상
  - 개별 호출을 공용 API 클라이언트로 통합해 유지보수성 개선
- Chores
  - 기본 API 베이스 경로를 /api에서 /api/v1로 버저닝
- 영향
  - 요청/응답 형식과 로그인·로그아웃 동작은 동일하며 UI 변화 없음
  - 서비스 전반의 안정성 및 확장성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->