### PR TITLE
[feat] 관리자 로그인, 대시보드 페이지 구현 

### DIFF
--- a/src/features/admin/api.ts
+++ b/src/features/admin/api.ts
@@ -1,0 +1,26 @@
+import adminAxios from '@/services/adminAxios';
+import { setAdminAuthHeader, clearAdminAuthHeader } from '@/services/user';
+
+// 관리자 로그인
+export const adminLogin = async (username: string, password: string) => {
+  const basicAuth = setAdminAuthHeader(username, password);
+  const res = await adminAxios.post(
+    '/admin/login',
+    { username, password },
+    {
+      headers: { Authorization: basicAuth },
+    }
+  );
+  return res.data;
+};
+
+// 관리자 로그아웃
+export const adminLogout = () => {
+  clearAdminAuthHeader();
+};
+
+// 관리자 대시보드 통계
+export const getAdminDashboard = async () => {
+  const res = await adminAxios.get('/admin/dashboard');
+  return res.data;
+};

--- a/src/features/admin/pages/AdminDashboardPage.tsx
+++ b/src/features/admin/pages/AdminDashboardPage.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react';
+import { getAdminDashboard, adminLogout } from '../api';
+import { useNavigate } from 'react-router-dom';
+
+interface AdminRecentProjectDto {
+  projectId: number;
+  projectName: string;
+  clientName: string;
+  createdAt: string;
+}
+
+interface AdminDashboardResponseDto {
+  totalUserCount: number;
+  todayUserCount: number;
+  todayFreelancerSignups: number;
+  todayClientSignups: number;
+  todayProjectCount: number;
+  todayReviewCount: number;
+  recentProjects: AdminRecentProjectDto[];
+}
+
+const AdminDashboardPage = () => {
+  const navigate = useNavigate();
+  const [data, setData] = useState<AdminDashboardResponseDto | null>(null);
+
+  useEffect(() => {
+    getAdminDashboard()
+      .then((res) => setData(res.data))
+      .catch((err) => {
+        console.error(err);
+        navigate('/admin/login');
+      });
+  }, [navigate]);
+
+  const handleLogout = () => {
+    adminLogout();
+    navigate('/admin/login');
+  };
+
+  if (!data) return <p className="text-center mt-10">로딩 중...</p>;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <nav className="bg-white shadow flex justify-between items-center px-6 h-16">
+        <h1 className="text-lg font-bold">픽플 관리자 대시보드</h1>
+        <button onClick={handleLogout} className="bg-gray-200 hover:bg-gray-300 px-4 py-1 rounded">
+          로그아웃
+        </button>
+      </nav>
+
+      <div className="max-w-7xl mx-auto p-6">
+        <h2 className="text-2xl font-bold mb-4">오늘 통계</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
+          <StatCard title="전체 사용자" value={`${data.totalUserCount}명`} color="bg-green-500" />
+          <StatCard title="오늘 가입자" value={`${data.todayUserCount}명`} color="bg-blue-500" />
+          <StatCard
+            title="오늘 프리랜서 가입"
+            value={`${data.todayFreelancerSignups}명`}
+            color="bg-purple-500"
+          />
+          <StatCard
+            title="오늘 클라이언트 가입"
+            value={`${data.todayClientSignups}명`}
+            color="bg-orange-500"
+          />
+          <StatCard
+            title="오늘 생성된 프로젝트"
+            value={`${data.todayProjectCount}개`}
+            color="bg-teal-500"
+          />
+          <StatCard
+            title="오늘 작성된 리뷰"
+            value={`${data.todayReviewCount}개`}
+            color="bg-pink-500"
+          />
+        </div>
+
+        <h2 className="text-2xl font-bold mt-10 mb-4">최근 등록된 프로젝트</h2>
+        <div className="bg-white rounded shadow overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  프로젝트명
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  클라이언트
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  생성일
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {data.recentProjects.map((p) => (
+                <tr key={p.projectId}>
+                  <td className="px-6 py-4 whitespace-nowrap">{p.projectName}</td>
+                  <td className="px-6 py-4 whitespace-nowrap">{p.clientName}</td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    {new Date(p.createdAt).toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const StatCard = ({ title, value, color }: { title: string; value: string; color: string }) => (
+  <div className="bg-white rounded shadow p-5 flex items-center space-x-4">
+    <div
+      className={`h-10 w-10 ${color} rounded flex items-center justify-center text-white font-bold`}
+    >
+      📊
+    </div>
+    <div>
+      <div className="text-sm text-gray-500">{title}</div>
+      <div className="text-lg font-bold">{value}</div>
+    </div>
+  </div>
+);
+
+export default AdminDashboardPage;

--- a/src/features/admin/pages/AdminLoginPage.tsx
+++ b/src/features/admin/pages/AdminLoginPage.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { adminLogin } from '../api';
+import { useNavigate } from 'react-router-dom';
+
+const AdminLoginPage = () => {
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await adminLogin(username, password);
+      navigate('/admin/dashboard');
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'response' in err) {
+        const axiosErr = err as { response?: { data?: { message?: string } } };
+        setError(axiosErr.response?.data?.message || '로그인 실패');
+      } else {
+        setError('로그인 실패');
+      }
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="bg-white rounded-lg shadow p-8 w-full max-w-md">
+        <h1 className="text-2xl font-bold mb-4 text-center">관리자 로그인</h1>
+        {error && <p className="text-red-500 mb-3">{error}</p>}
+        <form onSubmit={handleLogin} className="space-y-4">
+          <input
+            type="text"
+            placeholder="아이디"
+            className="w-full border p-2 rounded"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+          />
+          <input
+            type="password"
+            placeholder="비밀번호"
+            className="w-full border p-2 rounded"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          <button
+            type="submit"
+            className="w-full bg-blue-500 text-white py-2 rounded hover:bg-blue-600"
+          >
+            로그인
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AdminLoginPage;

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -8,6 +8,8 @@ import Home from '../pages/Home';
 import ProjectList from '../pages/ProjectList';
 import OverviewPage from '@/pages/OverviewPage';
 import FreelancerNotifications from '@/features/message/FreelancerNotificationsPage';
+import AdminLoginPage from '@/features/admin/pages/AdminLoginPage';
+import AdminDashboardPage from '@/features/admin/pages/AdminDashboardPage';
 
 export const routes = [
   { path: '/', element: <Home /> },
@@ -23,4 +25,6 @@ export const routes = [
     path: '/messages/notifications',
     element: <FreelancerNotifications />,
   },
+  { path: '/admin/login', element: <AdminLoginPage /> },
+  { path: '/admin/dashboard', element: <AdminDashboardPage /> },
 ];

--- a/src/services/adminAxios.ts
+++ b/src/services/adminAxios.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+import { getAdminAuthHeader } from './user';
+
+const adminAxios = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? '/api/v1',
+  withCredentials: true,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// 요청 시 자동으로 Authorization 헤더 붙이기
+adminAxios.interceptors.request.use((config) => {
+  const header = getAdminAuthHeader();
+  if (header) {
+    config.headers.Authorization = header;
+  }
+  return config;
+});
+
+export default adminAxios;

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -38,3 +38,17 @@ export const changePassword = async (data: UserPasswordChangeRequestDto): Promis
 export const deleteUser = async (): Promise<void> => {
   await axiosInstance.delete('/users');
 };
+
+export const getAdminAuthHeader = () => {
+  return localStorage.getItem('adminAuthHeader') || null;
+};
+
+export const setAdminAuthHeader = (username: string, password: string) => {
+  const basicAuth = 'Basic ' + btoa(`${username}:${password}`);
+  localStorage.setItem('adminAuthHeader', basicAuth);
+  return basicAuth;
+};
+
+export const clearAdminAuthHeader = () => {
+  localStorage.removeItem('adminAuthHeader');
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #27 

## 📝 작업 내용

> 관리자 전용 계정을 통한 로그인, 가입자 수, 최근 등록된 프로젝트 등을 통계로 해놓은 대시보드 페이지 구현 

## 🖼️ 스크린샷 (선택)
### 관리자 대시보드 페이지
<img width="1919" height="877" alt="관리자대시보드페이지구현" src="https://github.com/user-attachments/assets/91e451c6-feb6-43fb-a467-cea3e2b31363" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 관리자 로그인 페이지 추가: 아이디/비밀번호 입력, 오류 메시지 표시, 성공 시 대시보드로 이동.
  - 관리자 대시보드 도입: 주요 지표 카드(예: 사용자 수, 일일 가입)와 최근 등록 프로젝트 표 제공, 반응형 레이아웃.
  - 로그아웃 지원: 실행 시 로그인 화면으로 리다이렉트.
  - 관리자 전용 경로 추가: /admin/login, /admin/dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->