### PR TITLE
[feat] 제안서 페이지 백엔드 연동 완료

### DIFF
--- a/src/features/Proposal/ProposalMatchForm.tsx
+++ b/src/features/Proposal/ProposalMatchForm.tsx
@@ -27,11 +27,7 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
 
   const comment = targetType === 'client' ? '클라이언트에게 보내는 말' : '프리랜서에게 보내는 말';
 
-  const handleSubmit = async (
-    e: React.FormEvent,
-    submitAction: 'submit' | 'draft'
-  ): Promise<void> => {
-    e.preventDefault();
+  const handleSubmit = async (submitAction: 'submit' | 'draft'): Promise<void> => {
     if (!amount || amount <= 0) {
       alert('제안 금액을 입력해주세요.');
       return;
@@ -79,7 +75,12 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
             headers: { 'Content-Type': 'multipart/form-data' },
           });
           const newId = response.data?.data?.proposalId;
-          if (newId) setProposalId(newId);
+          if (typeof newId === 'number') {
+            setProposalId(newId);
+          } else {
+            console.warn('임시저장 후 서버에서 proposalId를 반환하지 않았습니다.');
+            throw new Error('Invalid response format');
+          }
         } else {
           await axiosInstance.patch(`/proposals/${proposalId}`, formData, {
             headers: { 'Content-Type': 'multipart/form-data' },
@@ -148,7 +149,7 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
         {/* 버튼 */}
         <button
           type="button"
-          onClick={(e) => handleSubmit(e as React.FormEvent, 'submit')}
+          onClick={() => handleSubmit('submit')}
           className="w-full py-3 bg-red-400 hover:bg-red-500 text-white font-semibold rounded-lg transition-colors"
         >
           제출하기
@@ -156,7 +157,7 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
 
         <button
           type="button"
-          onClick={(e) => handleSubmit(e as React.FormEvent, 'draft')}
+          onClick={() => handleSubmit('draft')}
           className="w-full py-3 bg-green-400 hover:bg-green-500 text-white font-semibold rounded-lg transition-colors"
         >
           임시저장

--- a/src/features/Proposal/ProposalMatchForm.tsx
+++ b/src/features/Proposal/ProposalMatchForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PortfolioUpload from './PortfolioUpload';
 import MatchingModal from './MatchingModal';
-import axios from 'axios';
+import { axiosInstance } from '../../services/axios';
 
 interface ProposalMatchFormProps {
   targetType: 'client' | 'freelancer';
@@ -19,7 +19,7 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
   const [message, setMessage] = useState<string>('');
   const [files, setFiles] = useState<File[]>([]);
   const [showModal, setShowModal] = useState(false);
-  const [action, setAction] = useState<'submit' | 'draft' | null>(null);
+  const [proposalId, setProposalId] = useState<number | null>(null);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
 
   const title =
@@ -27,7 +27,10 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
 
   const comment = targetType === 'client' ? '클라이언트에게 보내는 말' : '프리랜서에게 보내는 말';
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (
+    e: React.FormEvent,
+    submitAction: 'submit' | 'draft'
+  ): Promise<void> => {
     e.preventDefault();
     if (!amount || amount <= 0) {
       alert('제안 금액을 입력해주세요.');
@@ -40,33 +43,56 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
 
     try {
       const formData = new FormData();
-      formData.append('projectId', projectId.toString());
-      formData.append('description', message);
-      formData.append('proposedAmount', amount.toString());
+      const proposalData = {
+        projectId: projectId,
+        description: message,
+        proposedAmount: amount,
+      };
+
+      formData.append(
+        'proposal',
+        new Blob([JSON.stringify(proposalData)], { type: 'application/json' })
+      );
       // 여러 개 파일 추가
       files.forEach((file) => {
         formData.append('portfolioFiles', file);
-        // key 이름을 서버 DTO랑 맞춰야 함
       });
 
-      if (action === 'submit') {
-        await axios.post('/api/v1/proposals', formData, {
+      if (submitAction === 'submit') {
+        await axiosInstance.post('/proposals', formData, {
           headers: { 'Content-Type': 'multipart/form-data' },
         });
         setShowModal(true);
-      } else if (action === 'draft') {
-        await axios.post('/api/v1/proposals/draft', formData, {
-          headers: { 'Content-Type': 'multipart/form-data' },
-        });
+      } else if (submitAction === 'draft') {
+        let response;
+
+        if (!proposalId) {
+          response = await axiosInstance.post('/proposals/draft', formData, {
+            headers: { 'Content-Type': 'multipart/form-data' },
+          });
+
+          const newId = response.data?.data?.proposalId;
+          if (newId) setProposalId(newId);
+        } else {
+          const updateBody = {
+            description: message,
+            proposedAmount: amount,
+            portfolioFiles: files, // 백엔드에서 @RequestBody 받으므로 JSON 변환됨
+          };
+
+          await axiosInstance.patch(`/proposals/${proposalId}`, updateBody, {
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
 
         setToastMessage('임시저장 성공!');
         setTimeout(() => setToastMessage(null), 2000);
       }
     } catch (error) {
-      if (action === 'submit') {
+      if (submitAction === 'submit') {
         console.error('제출 실패:', error);
         alert('제출에 실패했습니다.');
-      } else if (action === 'draft') {
+      } else if (submitAction === 'draft') {
         console.error('임시저장 실패:', error);
         alert('임시저장에 실패했습니다.');
       }
@@ -80,7 +106,7 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
           {toastMessage}
         </div>
       )}
-      <form onSubmit={handleSubmit} className="space-y-6">
+      <form className="space-y-6">
         {/* 제안 금액 */}
         <div>
           <label htmlFor="amount" className="block font-medium mb-2">
@@ -121,16 +147,16 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
 
         {/* 버튼 */}
         <button
-          type="submit"
-          onClick={() => setAction('submit')}
+          type="button"
+          onClick={(e) => handleSubmit(e as React.FormEvent, 'submit')}
           className="w-full py-3 bg-red-400 hover:bg-red-500 text-white font-semibold rounded-lg transition-colors"
         >
           제출하기
         </button>
 
         <button
-          type="submit"
-          onClick={() => setAction('draft')}
+          type="button"
+          onClick={(e) => handleSubmit(e as React.FormEvent, 'draft')}
           className="w-full py-3 bg-green-400 hover:bg-green-500 text-white font-semibold rounded-lg transition-colors"
         >
           임시저장

--- a/src/features/Proposal/ProposalMatchForm.tsx
+++ b/src/features/Proposal/ProposalMatchForm.tsx
@@ -47,6 +47,7 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
         projectId: projectId,
         description: message,
         proposedAmount: amount,
+        status: submitAction === 'submit' ? 'SUBMITTED' : 'DRAFT',
       };
 
       formData.append(
@@ -59,32 +60,31 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
       });
 
       if (submitAction === 'submit') {
-        await axiosInstance.post('/proposals', formData, {
-          headers: { 'Content-Type': 'multipart/form-data' },
-        });
+        if (!proposalId) {
+          // 임시저장 없이 바로 제출한 경우
+          await axiosInstance.post('/proposals', formData, {
+            headers: { 'Content-Type': 'multipart/form-data' },
+          });
+        } else {
+          // 임시저장된 제안서가 이미 존재하면 PATCH로 업데이트 + 상태 변경
+          await axiosInstance.patch(`/proposals/${proposalId}`, formData, {
+            headers: { 'Content-Type': 'multipart/form-data' },
+          });
+        }
         setShowModal(true);
       } else if (submitAction === 'draft') {
         let response;
-
         if (!proposalId) {
-          response = await axiosInstance.post('/proposals/draft', formData, {
+          response = await axiosInstance.post('/proposals', formData, {
             headers: { 'Content-Type': 'multipart/form-data' },
           });
-
           const newId = response.data?.data?.proposalId;
           if (newId) setProposalId(newId);
         } else {
-          const updateBody = {
-            description: message,
-            proposedAmount: amount,
-            portfolioFiles: files, // 백엔드에서 @RequestBody 받으므로 JSON 변환됨
-          };
-
-          await axiosInstance.patch(`/proposals/${proposalId}`, updateBody, {
-            headers: { 'Content-Type': 'application/json' },
+          await axiosInstance.patch(`/proposals/${proposalId}`, formData, {
+            headers: { 'Content-Type': 'multipart/form-data' },
           });
         }
-
         setToastMessage('임시저장 성공!');
         setTimeout(() => setToastMessage(null), 2000);
       }

--- a/src/features/Proposal/ProposalMatchForm.tsx
+++ b/src/features/Proposal/ProposalMatchForm.tsx
@@ -21,6 +21,7 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
   const [showModal, setShowModal] = useState(false);
   const [proposalId, setProposalId] = useState<number | null>(null);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const title =
     targetType === 'client' ? '클라이언트에게 매칭 제안하기' : '프리랜서에게 매칭 제안하기';
@@ -28,6 +29,8 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
   const comment = targetType === 'client' ? '클라이언트에게 보내는 말' : '프리랜서에게 보내는 말';
 
   const handleSubmit = async (submitAction: 'submit' | 'draft'): Promise<void> => {
+    if (isSubmitting) return;
+
     if (!amount || amount <= 0) {
       alert('제안 금액을 입력해주세요.');
       return;
@@ -38,6 +41,7 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
     }
 
     try {
+      setIsSubmitting(true);
       const formData = new FormData();
       const proposalData = {
         projectId: projectId,
@@ -97,6 +101,8 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
         console.error('임시저장 실패:', error);
         alert('임시저장에 실패했습니다.');
       }
+    } finally {
+      setIsSubmitting(false);
     }
   };
   return (
@@ -150,17 +156,19 @@ const ProposalMatchForm: React.FC<ProposalMatchFormProps> = ({
         <button
           type="button"
           onClick={() => handleSubmit('submit')}
+          disabled={isSubmitting}
           className="w-full py-3 bg-red-400 hover:bg-red-500 text-white font-semibold rounded-lg transition-colors"
         >
-          제출하기
+          {isSubmitting ? '처리 중...' : '제출하기'}
         </button>
 
         <button
           type="button"
           onClick={() => handleSubmit('draft')}
+          disabled={isSubmitting}
           className="w-full py-3 bg-green-400 hover:bg-green-500 text-white font-semibold rounded-lg transition-colors"
         >
-          임시저장
+          {isSubmitting ? '저장 중...' : '임시저장'}
         </button>
       </form>
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #6 

## 📝 작업 내용

> 제안서 페이지 백엔드와 연동 완료했습니다.

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 제안서를 초안으로 저장하고 이후 이어서 작성할 수 있습니다.
  * 기존 초안/제안서가 있을 경우 새로 만들지 않고 자동으로 이어서 업데이트됩니다.
  * 제출 시 확인 모달이 표시되어 제출을 재확인합니다.
  * 초안 저장 시 즉시 토스트 알림으로 피드백을 제공합니다.

* Refactor
  * 제출·초안 저장 흐름이 버튼별 명확한 동작으로 재구성되어 사용성이 향상되었습니다.
  * 제출 중 버튼이 비활성화되고 처리 상태를 표시합니다.
  * 오류 처리와 성공/실패 피드백이 더 일관되게 작동합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->